### PR TITLE
Update auth config to use ‘silent’ SSO

### DIFF
--- a/app.js
+++ b/app.js
@@ -25,6 +25,8 @@ const strategy = new Auth0Strategy(
                  'http://localhost:3000/callback',
     scope: 'openid profile email',
     passReqToCallback: true,
+    prompt: 'none',
+    sso_logout_url: '/v2/logout',
   },
   ((
     req, issuer, audience, profile, accessToken,
@@ -34,6 +36,13 @@ const strategy = new Auth0Strategy(
     return callback(null, profile._json);
   }),
 );
+// Original implementation in `passport-openidconnect` ignore options by
+// returning `{}`.
+//
+// `passport-auth0-openidconnect` is supposed to override it but it doesn't.
+//
+// See: https://github.com/siacomuzzi/passport-openidconnect/blob/master/lib/strategy.js#L338
+Auth0Strategy.prototype.authorizationParams = (options) => options;
 passport.use(strategy);
 
 passport.serializeUser((user, done) => {

--- a/routes/index.js
+++ b/routes/index.js
@@ -30,6 +30,7 @@ router.get('/login', (req, res, next) => {
     }
   } else {
     passport.authenticate('auth0-oidc', {
+      prompt: req.query.prompt || 'none',
       state: uuidv4(),
     })(req, res, next);
   }
@@ -37,7 +38,7 @@ router.get('/login', (req, res, next) => {
 
 router.get(
   '/callback',
-  passport.authenticate('auth0-oidc', { failureRedirect: '/login' }),
+  passport.authenticate('auth0-oidc', { failureRedirect: '/login?prompt=true' }),
   (req, res) => {
     res.redirect(req.session.returnTo || '/');
   },


### PR DESCRIPTION
Taken from https://github.com/ministryofjustice/analytics-platform-rstudio-auth-proxy/commit/558de3c6ea3025bfdf3fa72481b38b228864aeb3